### PR TITLE
corrected handling of leak detection flag and added corresponding tests

### DIFF
--- a/tasks/lab.js
+++ b/tasks/lab.js
@@ -6,6 +6,8 @@
 * Licensed under the MIT license.
 */
 
+/*jshint bitwise: false*/
+
 "use strict";
 
 var path = require("path");
@@ -21,22 +23,22 @@ module.exports = function (grunt) {
 		};
 
 		var labOptions = [
-			{ name : "coverage",      flag : "-c", switch : true },
-			{ name : "color",         flag : "-C", switch : true },
-			{ name : "dryRun",        flag : "-d", switch : true },
-			{ name : "nodeEnv",       flag : "-e", switch : false },
-			{ name : "pattern",       flag : "-g", switch : false },
-			{ name : "global",        flag : "-G", switch : true },
-			{ name : "identifier",    flag : "-i", switch : false },
-			{ name : "ignoreGlobals", flag : "-I", switch : false },
-			{ name : "leakDetection", flag : "-l", switch : true },
-			{ name : "timeout",       flag : "-m", switch : false },
-			{ name : "reportFile",    flag : "-o", switch : false },
-			{ name : "parallel",      flag : "-p", switch : true },
-			{ name : "reporter",      flag : "-r", switch : false },
-			{ name : "silence",       flag : "-s", switch : true },
-			{ name : "minCoverage",   flag : "-t", switch : false },
-			{ name : "verbose",       flag : "-v", switch : true }
+			{ name : "coverage",      flag : "-c", is : { switch : true } },
+			{ name : "color",         flag : "-C", is : { switch : true } },
+			{ name : "dryRun",        flag : "-d", is : { switch : true } },
+			{ name : "nodeEnv",       flag : "-e", is : { switch : false } },
+			{ name : "pattern",       flag : "-g", is : { switch : false } },
+			{ name : "global",        flag : "-G", is : { switch : true } },
+			{ name : "identifier",    flag : "-i", is : { switch : false } },
+			{ name : "ignoreGlobals", flag : "-I", is : { switch : false } },
+			{ name : "leakDetection", flag : "-l", is : { switch : true, inverse : true } },
+			{ name : "timeout",       flag : "-m", is : { switch : false } },
+			{ name : "reportFile",    flag : "-o", is : { switch : false } },
+			{ name : "parallel",      flag : "-p", is : { switch : true } },
+			{ name : "reporter",      flag : "-r", is : { switch : false } },
+			{ name : "silence",       flag : "-s", is : { switch : true } },
+			{ name : "minCoverage",   flag : "-t", is : { switch : false } },
+			{ name : "verbose",       flag : "-v", is : { switch : true } }
 		];
 
 		var config = _.extend(defaultConfig, grunt.config.get("lab"));
@@ -47,10 +49,11 @@ module.exports = function (grunt) {
 			var option = _.first(_.where(labOptions, { name : configName }));
 
 			if (option) {
-				args.push(option.flag);
-
-				if (!option.switch) {
+				if (!option.is.switch) {
+					args.push(option.flag);
 					args.push(configValue);
+				} else if (!configValue ^ !option.is.inverse) {
+					args.push(option.flag);
 				}
 			}
 		});

--- a/test/lab.js
+++ b/test/lab.js
@@ -79,11 +79,51 @@ describe("grunt-lab plugin", function () {
 			before(function (done) {
 				spawnStub = sinon.stub(grunt.util, "spawn").callsArg(1);
 				task = runTask.task("lab", {
-					coverage    : true,
-					color       : true,
-					parallel    : true,
-					reporter    : "console",
-					minCoverage : 100
+					coverage      : true,
+					color         : true,
+					parallel      : true,
+					leakDetection : false,
+					reporter      : "console",
+					minCoverage   : 100
+				});
+
+				task.run(done);
+			});
+
+			after(function (done) {
+				spawnStub.restore();
+				task.clean(done);
+			});
+
+			it("executes the correct command", function (done) {
+				expect(spawnStub.calledOnce).to.equal(true);
+
+				expect(spawnStub.firstCall.args[0]).to.deep.equal({
+					cmd  : path.join(__dirname, "../node_modules", ".bin", "lab"),
+					args : [
+						"-c", "-C", "-p", "-l", "-r",
+						"console", "-t", 100, "test/lab.js"
+					],
+					opts : { stdio : "inherit" }
+				});
+
+				done();
+			});
+		});
+
+		describe("with inverted configuration", function () {
+			var task;
+			var spawnStub;
+
+			before(function (done) {
+				spawnStub = sinon.stub(grunt.util, "spawn").callsArg(1);
+				task = runTask.task("lab", {
+					coverage      : true,
+					color         : true,
+					parallel      : true,
+					leakDetection : true,
+					reporter      : "console",
+					minCoverage   : 100
 				});
 
 				task.run(done);


### PR DESCRIPTION
The use of the leakDetection flag `-l` is actually inverted compared to the meaning of the other commandline flags. If passed, it disables the `leakDetection` feature. This patch accounts for this type of behaviour by allowing for a switch to be marked as _inverted_.
