### PR TITLE
Add windows support (selecting .cmd binaries).

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,10 @@
 "use strict";
 
 var path = require("path");
+var getBin = require("./tasks/getBin");
 
 function localCommand (command) {
-	return path.join(__dirname, "node_modules", ".bin", command);
+	return path.join(__dirname, "node_modules", ".bin", getBin(command));
 }
 
 module.exports = function (grunt) {

--- a/tasks/getBin.js
+++ b/tasks/getBin.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = function (bin) {
+	if (/^win/.test(process.platform)) {
+		bin += ".cmd";
+	}
+	return bin;
+};

--- a/tasks/lab.js
+++ b/tasks/lab.js
@@ -9,6 +9,7 @@
 "use strict";
 
 var path = require("path");
+var getBin = require("./getBin");
 
 module.exports = function (grunt) {
 	var _ = grunt.util._;
@@ -59,7 +60,7 @@ module.exports = function (grunt) {
 
 		grunt.util.spawn({
 			args : _.flatten(args),
-			cmd  : path.join(path.resolve(require.resolve("lab")), "../../.bin/lab"),
+			cmd  : path.join(path.resolve(require.resolve("lab")), getBin("../../.bin/lab")),
 			opts : {
 				stdio : "inherit"
 			}

--- a/test/getBin.js
+++ b/test/getBin.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var Lab = require("lab");
+var lab = exports.lab = Lab.script();
+
+var getBin = require("../tasks/getBin");
+
+var describe = lab.describe;
+var it = lab.it;
+var expect = Lab.expect;
+
+describe("getBin utility", function () {
+
+
+	it("it should return .cmd on windows platform", function (done) {
+		var platform = process.platform;
+		process.platform='win32';
+		expect(getBin('foo')).to.equal('foo.cmd');
+		process.platform = platform;
+		done();
+	});
+
+	it("it should not return .cmd on platform without 'win' in them", function (done) {
+		var platform = process.platform;
+		process.platform='linux';
+		expect(getBin('foo')).to.equal('foo');
+		process.platform = platform;
+		done();
+	});
+
+});

--- a/test/lab.js
+++ b/test/lab.js
@@ -8,6 +8,8 @@ var sinon = require("sinon");
 var path = require("path");
 var grunt = require("grunt");
 
+var getBin = require("../tasks/getBin");
+
 var describe = lab.describe;
 var it = lab.it;
 var before = lab.before;
@@ -63,8 +65,8 @@ describe("grunt-lab plugin", function () {
 				expect(spawnStub.calledOnce).to.equal(true);
 
 				expect(spawnStub.firstCall.args[0]).to.deep.equal({
-					cmd  : path.join(__dirname, "../node_modules", ".bin", "lab"),
-					args : [ "test/lab.js" ],
+					cmd  : path.join(__dirname, "../node_modules", ".bin", getBin("lab")),
+					args : [ "test/getBin.js", "test/lab.js" ],
 					opts : { stdio : "inherit" }
 				});
 
@@ -108,10 +110,10 @@ describe("grunt-lab plugin", function () {
 					expect(spawnStub.calledOnce).to.equal(true);
 
 					expect(spawnStub.firstCall.args[0]).to.deep.equal({
-						cmd  : path.join(__dirname, "../node_modules", ".bin", "lab"),
+						cmd  : path.join(__dirname, "../node_modules", ".bin", getBin("lab")),
 						args : [
 							"-c", "-C", "-l", "-r",
-							"console", "-t", 100, "test/lab.js"
+							"console", "-t", 100, "test/getBin.js", "test/lab.js"
 						],
 						opts : { stdio : "inherit" }
 					});


### PR DESCRIPTION
Fixed grunt/lab tests for windows.
There is something wrong with the test: describe("resulting in an error"
It fails on windows, and not sure why. But then again, EVERYTHING failed on windows before I added these changes, so one failing test seems better than all. Again, likely to do with grunt-task-run being broken on windows. sigh...
