### PR TITLE
Added command line support in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ All configuration is optional. See the Lab [documentation](https://github.com/sp
 | silence          | boolean | false              | -s       |
 | minCoverage      | integer |                    | -t       |
 | verbose          | boolean | false              | -v       |
+| cmd              | [glob]  | []                 |          |
 
 An example Gruntfile using grunt-lab may look like this:
 ```

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^1.5.0",
     "grunt-run-task": "^0.2.0",
-    "lab": "^5.10",
+    "lab": "^6.2",
     "sinon": "^1.10.2"
   },
   "peerDependencies": {
-    "lab": "^5.10"
+    "lab": "^6.2"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-lab",
   "description": "Use the Spumko Lab test utility in Grunt.",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "homepage": "https://github.com/wtcross/grunt-lab",
   "author": {
     "name": "Tyler Cross",

--- a/tasks/lab.js
+++ b/tasks/lab.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
 
 		var defaultConfig = {
 			files : [ "test/**/*.js" ],
-			cmd: []
+			cmd   : []
 		};
 
 		var labOptions = [
@@ -56,7 +56,7 @@ module.exports = function (grunt) {
 			}
 		});
 
-		_.forIn(config.cmd, function(cmd){
+		_.forIn(config.cmd, function (cmd) {
 			args.push(cmd);
 		});
 

--- a/tasks/lab.js
+++ b/tasks/lab.js
@@ -17,7 +17,8 @@ module.exports = function (grunt) {
 		var done = this.async();
 
 		var defaultConfig = {
-			files : [ "test/**/*.js" ]
+			files : [ "test/**/*.js" ],
+			cmd: []
 		};
 
 		var labOptions = [
@@ -53,6 +54,10 @@ module.exports = function (grunt) {
 					args.push(configValue);
 				}
 			}
+		});
+
+		_.forIn(config.cmd, function(cmd){
+			args.push(cmd);
 		});
 
 		args.push(grunt.file.expand(config.files));

--- a/test/lab_spec.js
+++ b/test/lab_spec.js
@@ -85,7 +85,7 @@ describe("grunt-lab plugin", function () {
 					reporter             : "console",
 					minCoverage          : 100,
 					timeout              : 0,
-					cmd					 : ['-v']
+					cmd					 : ["-v"]
 				});
 				spawn = sinon.stub(task.grunt.util, "spawn").callsArg(1);
 

--- a/test/lab_spec.js
+++ b/test/lab_spec.js
@@ -84,7 +84,8 @@ describe("grunt-lab plugin", function () {
 					disableLeakDetection : true,
 					reporter             : "console",
 					minCoverage          : 100,
-					timeout              : 0
+					timeout              : 0,
+					cmd					 : ['-v']
 				});
 				spawn = sinon.stub(task.grunt.util, "spawn").callsArg(1);
 
@@ -118,7 +119,7 @@ describe("grunt-lab plugin", function () {
 						cmd  : path.join(__dirname, "..", "node_modules", "lab", "bin", "lab.cmd"),
 						args : [
 							"-c", "-C", "-l", "-r",
-							"console", "-t", 100, "-m", 0, "test/lab_spec.js"
+							"console", "-t", 100, "-m", 0, "-v", "test/lab_spec.js"
 						],
 						opts : { stdio : "inherit" }
 					});
@@ -149,7 +150,7 @@ describe("grunt-lab plugin", function () {
 						cmd  : path.join(__dirname, "..", "node_modules", "lab", "bin", "lab"),
 						args : [
 							"-c", "-C", "-l", "-r",
-							"console", "-t", 100, "-m", 0, "test/lab_spec.js"
+							"console", "-t", 100, "-m", 0, "-v", "test/lab_spec.js"
 						],
 						opts : { stdio : "inherit" }
 					});

--- a/test/lab_spec.js
+++ b/test/lab_spec.js
@@ -85,7 +85,7 @@ describe("grunt-lab plugin", function () {
 					reporter             : "console",
 					minCoverage          : 100,
 					timeout              : 0,
-					cmd					 : ["-v"]
+					cmd                  : [ "-v" ]
 				});
 				spawn = sinon.stub(task.grunt.util, "spawn").callsArg(1);
 


### PR DESCRIPTION
Added a cmd glob to enable custom command line calls. Sample usage (multiple outputs):

``` javascript
{
            color: true,
            coverage: true,
            minCoverage: 80,
            verbose: true,
            disableLeakDetection: true,
            timeout: 60 * 1000,
            debug: true,
            reporter: 'html',
            reportFile: './logs/lab-results.html',
            cmd:[
                '-r','console','-o','stdout',
                '-r','json','-o','./logs/lab-results.json'
            ],
            files: ['...']
}
```

becomes

```
'-C',
'-c',
'-t',
80,
'-v',
'-l',
'-m',
60000,
'-r',
'html',
'-o',
'./logs/lab-results.html',
'-r',
'console',
'-o',
'stdout',
'-r',
'json',
'-o',
'./logs/lab-results.json',
'...'
```
